### PR TITLE
(MAINT) ModuleMetadata initial version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: "ci"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  spec:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version:
+          - '2.7'
+          - '3.2'
+    name: "spec (ruby ${{ matrix.ruby_version }})"
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+    secrets: "inherit"
+    with:
+      ruby_version: ${{ matrix.ruby_version }}

--- a/.github/workflows/labeller.yml
+++ b/.github/workflows/labeller.yml
@@ -1,0 +1,22 @@
+name: community-labeller
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: puppetlabs/community-labeller@v0
+        name: Label issues or pull requests
+        with:
+          label_name: community
+          label_color: '5319e7'
+          org_membership: puppetlabs
+          token: ${{ secrets.IAC_COMMUNITY_LABELER }}

--- a/.github/workflows/mend.yml
+++ b/.github/workflows/mend.yml
@@ -1,0 +1,15 @@
+name: "mend"
+
+on:
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+
+  mend:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/mend_ruby.yml@main"
+    secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,11 @@
+name: "ci"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  spec:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_ci.yml@main"
+    secrets: "inherit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: "Release"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "main"
+
+jobs:
+  release:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+    secrets: "inherit"

--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -1,0 +1,20 @@
+name: "Release Prep"
+
+on:
+  workflow_dispatch:
+   inputs:
+    target:
+      description: "The target for the release. This can be a commit sha or a branch."
+      required: false
+      default: "main"
+    version:
+      description: "Version of gem to be released."
+      required: true
+
+jobs:
+  release_prep:
+    uses: "puppetlabs/cat-github-actions/.github/workflows/gem_release_prep.yml@main"
+    with:
+      target: "${{ github.event.inputs.target }}"
+      version: "${{ github.event.inputs.version }}"
+    secrets: "inherit"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+/vendor/
+
+Gemfile.lock
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,19 @@
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  TargetRubyVersion: 2.7
+
+Layout/LineLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Metrics/AbcSize:
+  CountRepeatedAttributes: false
+
+Gemspec/RequireMFA:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in puppet_module_metadata.gemspec
+gemspec
+
+group :development do
+  gem 'rake', '~> 13.0'
+  gem 'rspec', '~> 3.0'
+  gem 'rubocop', '~> 1.21'
+
+  gem 'pry'
+  gem 'pry-stack_explorer'
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2023 Craig Gumbley
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# puppetlabs-metadata_matrix_generator
+# PuppetModuleMetadata
+
+`PuppetModuleMetadata` provides some simple tasks for working with a Puppet modules `metadata.json` file.
+
+## Usage 
+
+For convenience, some items are exposed via rake tasks.
+
+Add the following line to your Rakefile:
+
+``` ruby
+require 'puppet_module_metadata/rake_tasks'
+```
+Then from a shell, you can run commands such as the example below.
+
+``` bash
+bundle exec rake metadata::matrix::generate
+```
+
+Alternatively, the gem can be used as a normal library.
+
+```ruby
+require 'puppet_module_metadata'
+
+matrix= ModuleMetadata::Matrix::Generator.new
+matrix.generate
+```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
+require_relative 'lib/puppet_module_metadata/rake_tasks'
+
+RSpec::Core::RakeTask.new(:spec)
+
+RuboCop::RakeTask.new
+
+task default: %i[spec rubocop]

--- a/lib/puppet_module_metadata.rb
+++ b/lib/puppet_module_metadata.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative 'puppet_module_metadata/matrix'
+require_relative 'puppet_module_metadata/version'

--- a/lib/puppet_module_metadata/matrix.rb
+++ b/lib/puppet_module_metadata/matrix.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative 'matrix/generate'
+require_relative 'matrix/spec'
+require_relative 'matrix/acceptance'
+
+module ModuleMetadata
+  module Matrix
+    IMAGE_TABLE = {
+      'RedHat-7' => 'rhel-7',
+      'RedHat-8' => 'rhel-8',
+      'RedHat-9' => 'rhel-9',
+      'SLES-12' => 'sles-12',
+      'SLES-15' => 'sles-15',
+      'Windows-2016' => 'windows-2016',
+      'Windows-2019' => 'windows-2019',
+      'Windows-2022' => 'windows-2022'
+    }.freeze
+
+    DOCKER_PLATFORMS = {
+      'CentOS-6' => 'litmusimage/centos:6',
+      'CentOS-7' => 'litmusimage/centos:7',
+      'CentOS-8' => 'litmusimage/centos:stream8', # Support officaly moved to Stream8, metadata is being left as is
+      'Rocky-8' => 'litmusimage/rockylinux:8',
+      'AlmaLinux-8' => 'litmusimage/almalinux:8',
+      'Debian-9' => 'litmusimage/debian:9',
+      'Debian-10' => 'litmusimage/debian:10',
+      'Debian-11' => 'litmusimage/debian:11',
+      'OracleLinux-6' => 'litmusimage/oraclelinux:6',
+      'OracleLinux-7' => 'litmusimage/oraclelinux:7',
+      'Scientific-6' => 'litmusimage/scientificlinux:6',
+      'Scientific-7' => 'litmusimage/scientificlinux:7',
+      'Ubuntu-18.04' => 'litmusimage/ubuntu:18.04',
+      'Ubuntu-20.04' => 'litmusimage/ubuntu:20.04',
+      'Ubuntu-22.04' => 'litmusimage/ubuntu:22.04'
+    }.freeze
+
+    # This table uses the latest version in each collection for accurate
+    # comparison when evaluating puppet requirements from the metadata
+    COLLECTION_TABLE = [
+      {
+        puppet_maj_version: 7,
+        ruby_version: 2.7
+      },
+      {
+        puppet_maj_version: 8,
+        ruby_version: 3.2
+      }
+    ].freeze
+  end
+end

--- a/lib/puppet_module_metadata/matrix/acceptance.rb
+++ b/lib/puppet_module_metadata/matrix/acceptance.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module ModuleMetadata
+  module Matrix
+    # The AcceptanceMatrix class defines the of the matrix used for acceptance tests
+    class AcceptanceMatrix
+      attr_accessor :platforms, :collection
+
+      def initialize
+        @platforms = []
+        @collection = []
+      end
+
+      # Add a platform to the matrix
+      # @param label [String] The label of the platform
+      # @param provider [String] The provider of the platform
+      # @param image [String] The image of the platform
+      def add_platform(label, provider, image)
+        @platforms.append(
+          {
+            label: label,
+            provider: provider,
+            image: image
+          }
+        )
+      end
+
+      # Add a cell to the matrix
+      # @param collection [String] The collection of the cell
+      def add_collection(collection)
+        @collection.append(collection)
+      end
+
+      # Return the matrix as a JSON string
+      # @return [String] The matrix as a JSON string
+      def to_s
+        JSON.generate(
+          {
+            platforms: @platforms,
+            collection: @collection
+          }
+        )
+      end
+
+      # Return the number of cells in the matrix
+      # @return [Integer] The number of cells in the matrix
+      def length
+        @platforms.length * @collection.length
+      end
+    end
+  end
+end

--- a/lib/puppet_module_metadata/matrix/generate.rb
+++ b/lib/puppet_module_metadata/matrix/generate.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'puppet_metadata'
+
+module ModuleMetadata
+  module Matrix
+    # The Matrix class contains helpers for generating a matrix of platforms and
+    # puppet versions to test against.
+    class Generator
+      def initialize(exclude_platforms = [])
+        @exclude_list = exclude_platforms || []
+        @acceptance_matrix = AcceptanceMatrix.new
+        @spec_matrix = SpecMatrix.new
+
+        metadata_path = ENV['TEST_MATRIX_FROM_METADATA'] || 'metadata.json'
+        @metadata = PuppetMetadata.read(metadata_path)
+      end
+
+      # Generate the CI matrix for acceptance tests and spec tests
+      def generate
+        generate_platforms
+        generate_collections
+
+        set_output('matrix', @acceptance_matrix.to_s)
+        set_output('spec_matrix', @spec_matrix.to_s)
+
+        puts "Created matrix with #{@acceptance_matrix.length + @spec_matrix.length} cells:"
+        puts "  - Acceptance Test Cells: #{@acceptance_matrix.length}"
+        puts "  - Spec Test Cells: #{@spec_matrix.length}"
+      end
+
+      private
+
+      # Return an array of image keys from the metadata
+      # @return [Array] An array of image keys from the metadata
+      def image_keys
+        image_keys = []
+        @metadata.operatingsystems.each_key do |os|
+          @metadata.operatingsystems[os].each do |release|
+            image_keys.append("#{os}-#{release}")
+          end
+        end
+        image_keys
+      end
+
+      # Return true if the image_key is in the image table and not in the exclude list
+      # @param image_key [String] The image key to check
+      # @return [Boolean] True if the image_key is in the image table and not in the exclude list
+      def in_image_table?(image_key)
+        ModuleMetadata::Matrix::IMAGE_TABLE.key?(image_key) && !@exclude_list.include?(image_key.downcase)
+      end
+
+      # Return true if the image_key is in the docker table and not in the exclude list
+      # @param image_key [String] The image key to check
+      # @return [Boolean] True if the image_key is in the docker table and not in the exclude list
+      def in_docker_table?(image_key)
+        ModuleMetadata::Matrix::DOCKER_PLATFORMS.key?(image_key) && !@exclude_list.include?(image_key.downcase)
+      end
+
+      # Generate the required platforms based on the metadata.json file for
+      # acceptance tests.
+      def generate_platforms
+        image_keys.each do |image_key|
+          # Set platforms based on declared operating system support
+          if in_image_table?(image_key)
+            @acceptance_matrix.add_platform(
+              image_key,
+              'provision::provision_service',
+              ModuleMetadata::Matrix::IMAGE_TABLE[image_key]
+            )
+            next
+          end
+
+          if in_docker_table?(image_key)
+            @acceptance_matrix.add_platform(
+              image_key,
+              'provision::docker',
+              ModuleMetadata::Matrix::DOCKER_PLATFORMS[image_key]
+            )
+            next
+          end
+
+          puts "::debug::Cannot find image for #{image_key}" unless @exclude_list.include?(image_key.downcase)
+        end
+      end
+
+      # Gemerate the required collections based on the metadata.json file
+      # for acceptance and spec tests.
+      def generate_collections
+        ModuleMetadata::Matrix::COLLECTION_TABLE.each do |collection|
+          # Test against the "largest" puppet version in a collection, e.g. `7.9999`
+          # to allow puppet requirements with a non-zero lower bound on minor/patch versions.
+          # This assumes that such a boundary will always allow the latest actually
+          # existing puppet version of a release stream, trading off simplicity vs accuracy here.
+          version = Gem::Version.new("#{collection[:puppet_maj_version]}.99.99")
+          next unless @metadata.satisfies_requirement?('puppet', version.to_s)
+
+          @acceptance_matrix.add_collection("puppet#{collection[:puppet_maj_version]}-nightly")
+          @spec_matrix.add_collection("~> #{collection[:puppet_maj_version]}.0", collection[:ruby_version])
+        end
+      end
+
+      # Sets an output variable in GitHub Actions. If the GITHUB_OUTPUT environment
+      # variable is not set, this will fail with an exit code of 1 and
+      # send an ::error:: message to the GitHub Actions log.
+      # @param name [String] The name of the output variable
+      # @param value [String] The value of the output variable
+      def set_output(name, value)
+        # Get the output path
+        output = ENV.fetch('GITHUB_OUTPUT')
+
+        # Write the output variable to GITHUB_OUTPUT
+        File.open(output, 'a') do |f|
+          f.puts "#{name}=#{value}"
+        end
+      rescue KeyError
+        puts '::error::GITHUB_OUTPUT environment variable not set.'
+        exit 1
+      end
+    end
+  end
+end

--- a/lib/puppet_module_metadata/matrix/spec.rb
+++ b/lib/puppet_module_metadata/matrix/spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module ModuleMetadata
+  module Matrix
+    # The SpecMatrix class defines the of the matrix used for spec tests
+    class SpecMatrix
+      attr_accessor :include
+
+      def initialize
+        @include = []
+      end
+
+      # Add a cell to the matrix
+      # @param puppet_maj_version [String] The major version of Puppet
+      # @param ruby_version [String] The version of Ruby
+      def add_collection(puppet_maj_version, ruby_version)
+        @include.append(
+          {
+            puppet_version: puppet_maj_version,
+            ruby_version: ruby_version
+          }
+        )
+      end
+
+      # Return the matrix as a JSON string
+      # @return [String] The matrix as a JSON string
+      def to_s
+        JSON.generate(
+          {
+            include: @include
+          }
+        )
+      end
+
+      # Return the number of cells in the matrix
+      # @return [Integer] The number of cells in the matrix
+      def length
+        @include.length
+      end
+    end
+  end
+end

--- a/lib/puppet_module_metadata/rake_tasks.rb
+++ b/lib/puppet_module_metadata/rake_tasks.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rake'
+require 'rake/tasklib'
+require_relative '../puppet_module_metadata'
+
+namespace :metadata do
+  namespace :matrix do
+    # metadata:matrix:generate task will generate a matrix of supported
+    # platforms and ruby versions based on the metadata.json file in the
+    # current directory.
+    #
+    # Platforms can be excluded by passing a space separated list as a parameter.
+    #
+    # Additionally, the TEST_MATRIX_FROM_METADATA environment variable can be
+    # set to a path to a metadata.json file to use instead of the default.
+    # @param exclude [Array] An array of platforms to exclude from the matrix
+    #
+    # @example
+    #  rake metadata:matrix:generate
+    #
+    # @example
+    #   rake 'metadata:matrix:generate[centos-7 ubuntu-18.04]''
+    desc 'Generate a CI matrix from the metadata.json file.'
+    task :generate, [:exclude] do |_task, args|
+      generator = ModuleMetadata::Matrix::Generator.new(args[:exclude])
+      generator.generate
+    end
+  end
+end

--- a/lib/puppet_module_metadata/version.rb
+++ b/lib/puppet_module_metadata/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module PuppetModuleMetadata
+  VERSION = '0.1.0'
+end

--- a/puppet_module_metadata.gemspec
+++ b/puppet_module_metadata.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative 'lib/puppet_module_metadata/version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'puppet_module_metadata'
+  spec.version = PuppetModuleMetadata::VERSION
+  spec.authors = ['Puppet, Inc']
+  spec.email = ['info@puppet.com']
+
+  spec.summary = 'A useful library for working with Puppet module metadata.json files'
+  spec.description = 'A useful library for working with Puppet module metadata.json files'
+  spec.homepage = 'https://puppet.com'
+  spec.license = 'MIT'
+  spec.required_ruby_version = '>= 2.7'
+
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/puppetlabs/puppet_module_metadata'
+  spec.metadata['changelog_uri'] = 'https://github.com/puppetlabs/puppet_module_metadata/blob/main/CHANGELOG.md'
+
+  spec.files = Dir[
+    'README.md',
+    'LICENSE',
+    'lib/**/*',
+  ]
+
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_runtime_dependency 'puppet_metadata', '~> 2.0'
+end

--- a/spec/fixtures/fake_metadata.json
+++ b/spec/fixtures/fake_metadata.json
@@ -1,0 +1,46 @@
+{
+  "name": "puppetlabs-fake_module",
+  "version": "3.1.0",
+  "author": "puppetlabs",
+  "summary": "fake_module is a test",
+  "license": "Apache-2.0",
+  "source": "it has no source",
+  "project_page": "it has no project page",
+  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.0.0 < 9.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "18.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 7.0.0 < 9.0.0"
+    }
+  ],
+  "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
+  "template-ref": "tags/2.7.4",
+  "pdk-version": "2.7.4"
+}

--- a/spec/fixtures/metadata.json
+++ b/spec/fixtures/metadata.json
@@ -1,0 +1,111 @@
+{
+  "name": "puppetlabs-concat",
+  "version": "7.3.1",
+  "author": "puppetlabs",
+  "summary": "Construct files from multiple fragments.",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/puppetlabs-concat",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-concat",
+  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.13.1 < 9.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12",
+        "15"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "18.04",
+        "20.04",
+        "22.04"
+      ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "10",
+        "2012 R2 Core",
+        "2012",
+        "2012 R2",
+        "2016",
+        "2022"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "7.1"
+      ]
+    },
+    {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 7.0.0 < 9.0.0"
+    }
+  ],
+  "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
+  "template-ref": "heads/main-0-g9375381",
+  "pdk-version": "2.6.1"
+}

--- a/spec/puppet_module_metadata_spec.rb
+++ b/spec/puppet_module_metadata_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'tempfile'
+
+# rubocop:disable Metrics/BlockLength
+RSpec.describe ModuleMetadata::Matrix::Generator do
+  before(:all) do
+    ENV['TEST_MATRIX_FROM_METADATA'] = 'spec/fixtures/fake_metadata.json'
+  end
+
+  context 'without arguments' do
+    subject(:generator) { described_class.new }
+
+    let(:github_output) { Tempfile.new('github_output') }
+    let(:github_output_content) { github_output.read }
+
+    before(:each) do
+      ENV['GITHUB_OUTPUT'] = github_output.path
+    end
+
+    let(:expected_stdout) do
+      <<~OUTPUT
+        ::debug::Cannot find image for Ubuntu-14.04
+        Created matrix with 8 cells:
+          - Acceptance Test Cells: 6
+          - Spec Test Cells: 2
+      OUTPUT
+    end
+
+    it 'generates a matrix' do
+      expect { generator.generate }.to output(expected_stdout).to_stdout
+
+      expect(github_output_content).to include(
+        [
+          'matrix={',
+          '"platforms":[',
+          '{"label":"CentOS-6","provider":"provision::docker","image":"litmusimage/centos:6"},',
+          '{"label":"RedHat-8","provider":"provision::provision_service","image":"rhel-8"},',
+          '{"label":"Ubuntu-18.04","provider":"provision::docker","image":"litmusimage/ubuntu:18.04"}',
+          '],',
+          '"collection":[',
+          '"puppet7-nightly","puppet8-nightly"',
+          ']',
+          '}'
+        ].join
+      )
+
+      expect(github_output_content).to include(
+        'spec_matrix={"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}' # rubocop:disable Layout/LineLength
+      )
+    end
+  end
+
+  context 'with exclude list' do
+    subject(:generator) { described_class.new(%w[centos-6 redhat-8]) }
+
+    let(:github_output) { Tempfile.new('github_output') }
+    let(:github_output_content) { github_output.read }
+
+    before(:each) do
+      ENV['GITHUB_OUTPUT'] = github_output.path
+    end
+
+    let(:expected_stdout) do
+      <<~OUTPUT
+        ::debug::Cannot find image for Ubuntu-14.04
+        Created matrix with 4 cells:
+          - Acceptance Test Cells: 2
+          - Spec Test Cells: 2
+      OUTPUT
+    end
+
+    it 'generates a matrix' do
+      expect { generator.generate }.to output(expected_stdout).to_stdout
+
+      expect(github_output_content).to include(
+        [
+          'matrix={',
+          '"platforms":[',
+          '{"label":"Ubuntu-18.04","provider":"provision::docker","image":"litmusimage/ubuntu:18.04"}',
+          '],',
+          '"collection":[',
+          '"puppet7-nightly","puppet8-nightly"',
+          ']',
+          '}'
+        ].join
+      )
+
+      expect(github_output_content).to include(
+        'spec_matrix={"include":[{"puppet_version":"~> 7.0","ruby_version":2.7},{"puppet_version":"~> 8.0","ruby_version":3.2}]}' # rubocop:disable Layout/LineLength
+      )
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'puppet_module_metadata'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
This PR introduces a basic library for working with a modules metadata.json file.

It is largely inspired by the version maintained by vox, however the task exposed generates a CI matrix as per puppet's usual practice.

The library makes use of the Metadata data structure provided by the `puppet_metadata` gem and over time I would expect further alignment.


The aim of this library is to decouple "matrix_from_metadata_v2" from puppet_litmus so that they can be independently maintained and released.